### PR TITLE
修复spring boot 2.0 项目中包含多个module, gradle build时出现异常的问题（找不到依赖项目的类等）

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,5 +83,9 @@ subprojects {
         mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
       }
     }
+  
+    jar {
+      enabled = true
+    }
 }
 


### PR DESCRIPTION
参考地址：https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/html/

By default, when the bootJar or bootWar tasks are configured, the jar or war tasks are disabled. A project can be configured to build both an executable archive and a normal archive at the same time by enabling the jar or war task:
```
jar {
  enabled = true
}
```